### PR TITLE
errorHandler -> errorhandler

### DIFF
--- a/examples/openid-connect-example.js
+++ b/examples/openid-connect-example.js
@@ -17,7 +17,7 @@ var crypto = require('crypto')
   logger = require('morgan'),
   bodyParser = require('body-parser'),
   cookieParser = require('cookie-parser'),
-  errorHandler = require('errorHandler'),
+  errorHandler = require('errorhandler'),
   methodOverride = require('method-override');
 
 var app = express();


### PR DESCRIPTION
The proper module name is errorhandler, using errorHandler breaks this example on case-sensitive filesystems.
