### PR TITLE
Fixes

### DIFF
--- a/index.js
+++ b/index.js
@@ -951,7 +951,7 @@ OpenIDConnect.prototype.token = function() {
 				                            .populate('accessTokens')
 				                            .populate('refreshTokens')
                                             .exec(function(err, auth) {
-                                                if(!auth.access.length && !auth.refresh.length) {
+                                                if(auth.access && !auth.access.length && auth.refresh && !auth.refresh.length) {
                                                     auth.destroy();
                                                 }
                                             });

--- a/index.js
+++ b/index.js
@@ -912,7 +912,7 @@ OpenIDConnect.prototype.token = function() {
 		                            .populate('accessTokens')
 		                            .populate('refreshTokens')
                                     .exec(function(err, auth) {
-                                        if(!auth.access.length && !auth.refresh.length) {
+                                        if(auth.access && !auth.access.length && auth.refresh && !auth.refresh.length) {
                                             auth.destroy();
                                         }
                                     });


### PR DESCRIPTION
If auth.access and/or auth.refresh are undefined, these lines caused a crash. This way crash is avoided, but I'm not sure if the functionality is correct... May be better something like the following?
if ((!auth.access || !auth.access.length) && (!auth.refresh || !auth.refresh.length))...